### PR TITLE
fix: add missing instructions and fix typo in ship and address skills (fixes #4)

### DIFF
--- a/commands/address.md
+++ b/commands/address.md
@@ -58,6 +58,7 @@ When replying to review or issue comments:
 - Never edit or PATCH the original review comment body.
 - For review comments, always post a new reply using `in_reply_to` with `gh api repos/<org>/<repo>/pulls/<pr>/comments --method POST --field in_reply_to=<comment_id> --field body="..."`.
 - For issue comments, post a new comment with `gh api repos/<org>/<repo>/issues/<pr>/comments --method POST --field body="..."`.
+- To avoid shell expansion issues with backticks or special characters, write the reply body to `.tmp/reply.txt` and use `--field body=@.tmp/reply.txt` to read it directly from the file.
 - If a mistaken edit already happened, leave it and add a new reply noting the fix.
 
 After I approve:
@@ -66,4 +67,5 @@ After I approve:
 - Commit with message referencing the addressed comments
 - Push the changes
 - Draft responses for each comment (don't post them — show me first)
+- Use the **humanizer** skill on each reply draft before presenting it
 - The comment should be concise and explain what was done to fix the issue or why it won't be fixed; no "good catch" or "thanks for pointing that out" phrases.

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: "Prreparing and shipping code changes"
+description: "Preparing and shipping code changes"
 ---
 
 Prepare to ship the current work:
@@ -12,16 +12,19 @@ After confirmation:
 
 - If on main/master: create branch named `<type>/<short-description>` (e.g., `fix/null-pointer-auth`, `feat/user-export`)
 - Stage only files relevant to this task, unless I instruct otherwise
-- Commit with this structure:
+- Use the **humanizer** skill on the commit message before committing
+- Commit using Conventional Commits. The header format is `<type>[optional scope]: <description>`, where type is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, or `ci`. The scope is optional and indicates the affected component. The description should be concise, in imperative mood, and not end with a period.
+- The commit body should explain what problem is being solved, the reasoning behind the approach, and how the solution works. Do not list modified files or describe individual changes — those are visible from the diff. Use this structure:
 
   ```text
-  <commit header, according to conventional commits>
+  <type>[optional scope]: <description>
 
   Issue: <summarize user prompts received during this session into a concise description of the issue>
   Solution: <what was done and why, 2-5 lines>
   ```
 
-- Push and create a PR with:
+- Use the **humanizer** skill on the PR body before creating the PR
+- Write the PR body to `.tmp/pr-body.md`, then create the PR using `gh pr create --body-file .tmp/pr-body.md`:
   - Title matching the commit's short description
   - Body containing the Solution section expanded with context for reviewers
   - Link to relevant issues if mentioned in session


### PR DESCRIPTION
## Summary

The ship and address skills were missing key instructions that had been removed from `~/.claude/CLAUDE.md` when those skills were introduced. The ship skill also had a typo in its frontmatter.

## Changes

- `commands/ship.md`: fixed the `"Prreparing"` typo, added humanizer skill references for commit messages and PR bodies, added conventional commits format detail (types, scope, imperative mood, body guidelines), specified `gh pr create --body-file .tmp/pr-body.md` for PR creation.
- `commands/address.md`: added guidance on using `--field body=@.tmp/reply.txt` to avoid shell expansion issues, added humanizer skill reference for reply drafts.

### Bug details

**Root cause:** When the shipping and PR formatting instructions were moved out of `~/.claude/CLAUDE.md` in favor of the `/ship` and `/address` skills, the skills were not updated to contain the full detail — conventional commits format, `--body-file` method, shell expansion guidance, and humanizer references were all missing.

**Fix:** Added the missing instructions to both skills and corrected the typo.

## Checklist

- [x] All tasks from the issue are completed
- [x] Tests added/updated (N/A — documentation-only repo)
- [x] All pre-commit hooks pass
- [x] All existing tests still pass (N/A)
- [x] No new TODOs in code
- [x] No new dependencies
- [x] Docs updated (N/A — the changed files are themselves the docs)
- [x] Commit messages follow conventional commits

## Manual Steps Required

None
