### PR TITLE
docs: fix stale cross-references, template URL, and enhance /learn command

### DIFF
--- a/ADMITTANCE.md
+++ b/ADMITTANCE.md
@@ -15,7 +15,7 @@ Not every project needs governance. If it's a throwaway experiment, a one-off sc
    - Build and test commands
    - Reference to docs/ for detailed documentation
 3. **Set up guardrails:**
-   - Install and configure the linter, formatter, and type checker for the stack (see Standard Guardrails above).
+   - Install and configure the linter, formatter, and type checker for the stack (see Standard Guardrails in CONSTITUTION.md).
    - Create pre-commit hooks that run lint + format + type check + test.
    - Set up CI (GitHub Actions recommended) with build + test + lint.
    - Enable branch protection on main/master.
@@ -39,7 +39,7 @@ Run the documentation commands in this order. Each one builds on the previous.
 
 ## Phase 4: Register
 
-Add the project to the Registry of Lands table above. Mark each column honestly.
+Add the project to the Registry of Lands table in FEDERATION.md. Mark each column honestly.
 
 ## Checklist: When Is a Land "Governed"?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Governance
 
+![Workflow Diagram](images/workflow-diagram.svg)
+
 Federated governance framework for AI-assisted software projects.
 
 ## What This Is

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -13,7 +13,12 @@ Identify from this session:
 3. **Corrections:** What in CLAUDE.md was wrong or outdated?
 4. **Missing context:** What project knowledge would have helped from the start?
 
-For each item, draft an update:
+Before drafting any updates, deduplicate and prune:
+
+1. **Deduplication:** For each learning identified above, check if CLAUDE.md already covers the topic. If it does and the existing entry is correct and complete, skip it. If it covers the topic but needs updating, propose an update to the existing entry rather than adding a new one.
+2. **Pruning:** Review existing CLAUDE.md entries that relate to this session's work. If any are now outdated, incorrect, or contradicted by what happened in this session, propose their removal or update. Stale knowledge is worse than missing knowledge.
+
+For each remaining item, draft an update:
 
 - Blockers → Add to a "Known Pitfalls" or "Gotchas" section
 - Discoveries → Add to relevant technical section (create if needed)

--- a/images/workflow-diagram.svg
+++ b/images/workflow-diagram.svg
@@ -1,0 +1,212 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" font-family="'JetBrains Mono', 'Fira Code', 'SF Mono', monospace">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&amp;display=swap');
+    </style>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000" flood-opacity="0.15"/>
+    </filter>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-amber" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#d97706"/>
+    </marker>
+    <marker id="arrow-emerald" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#059669"/>
+    </marker>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="720" fill="url(#bg)" rx="12"/>
+
+  <!-- Phase labels -->
+  <text x="155" y="52" fill="#94a3b8" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="3">PLAN</text>
+  <text x="460" y="52" fill="#94a3b8" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="3">IMPLEMENT</text>
+  <text x="770" y="52" fill="#94a3b8" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="3">REVIEW</text>
+  <text x="1060" y="52" fill="#94a3b8" font-size="11" font-weight="600" text-anchor="middle" letter-spacing="3">REFLECT</text>
+
+  <!-- Phase separator lines -->
+  <line x1="310" y1="38" x2="310" y2="680" stroke="#334155" stroke-width="1" stroke-dasharray="4,6"/>
+  <line x1="620" y1="38" x2="620" y2="680" stroke="#334155" stroke-width="1" stroke-dasharray="4,6"/>
+  <line x1="920" y1="38" x2="920" y2="680" stroke="#334155" stroke-width="1" stroke-dasharray="4,6"/>
+
+  <!-- ==================== PLAN PHASE ==================== -->
+
+  <!-- /bug command -->
+  <rect x="50" y="100" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="72" y="124" fill="#60a5fa" font-size="13" font-weight="700">/bug</text>
+  <text x="72" y="142" fill="#94a3b8" font-size="10">Interview → bug report issue</text>
+
+  <!-- /feature command -->
+  <rect x="50" y="170" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="72" y="194" fill="#60a5fa" font-size="13" font-weight="700">/feature</text>
+  <text x="72" y="212" fill="#94a3b8" font-size="10">Interview → feature spec issue</text>
+
+  <!-- /tech command -->
+  <rect x="50" y="240" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="72" y="264" fill="#60a5fa" font-size="13" font-weight="700">/tech</text>
+  <text x="72" y="282" fill="#94a3b8" font-size="10">Interview → tech debt issue</text>
+
+  <!-- GitHub Issue artifact -->
+  <rect x="100" y="340" width="160" height="50" rx="8" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="180" y="362" fill="#c4b5fd" font-size="12" font-weight="600" text-anchor="middle">GitHub Issue</text>
+  <text x="180" y="378" fill="#94a3b8" font-size="9" text-anchor="middle">scope + acceptance criteria</text>
+
+  <!-- Arrows from commands to issue -->
+  <path d="M155,154 L155,172" fill="none" stroke="#64748b" stroke-width="1"/>
+  <path d="M155,224 L155,242" fill="none" stroke="#64748b" stroke-width="1"/>
+  <line x1="155" y1="294" x2="155" y2="340" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ==================== HUMAN CHECKPOINT 1 ==================== -->
+  <rect x="72" y="420" width="216" height="46" rx="23" fill="#451a03" stroke="#d97706" stroke-width="1.5"/>
+  <text x="180" y="440" fill="#fbbf24" font-size="11" font-weight="600" text-anchor="middle">HUMAN CHECKPOINT</text>
+  <text x="180" y="455" fill="#fcd34d" font-size="9" text-anchor="middle">Review &amp; approve the issue</text>
+
+  <!-- Arrow from issue to checkpoint -->
+  <line x1="180" y1="390" x2="180" y2="420" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow-amber)"/>
+
+  <!-- ==================== IMPLEMENT PHASE ==================== -->
+
+  <!-- /implement command -->
+  <rect x="355" y="170" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="377" y="194" fill="#60a5fa" font-size="13" font-weight="700">/implement</text>
+  <text x="377" y="212" fill="#94a3b8" font-size="10">Code + tests + doc updates</text>
+
+  <!-- /ship command -->
+  <rect x="355" y="270" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="377" y="294" fill="#60a5fa" font-size="13" font-weight="700">/ship</text>
+  <text x="377" y="312" fill="#94a3b8" font-size="10">Branch, commit, push, draft PR</text>
+
+  <!-- Draft PR artifact -->
+  <rect x="405" y="370" width="160" height="50" rx="8" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="485" y="392" fill="#c4b5fd" font-size="12" font-weight="600" text-anchor="middle">Draft PR</text>
+  <text x="485" y="408" fill="#94a3b8" font-size="9" text-anchor="middle">fixes #N + checklist</text>
+
+  <!-- Arrow from checkpoint 1 to /implement -->
+  <path d="M288,443 Q322,443 355,197" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Arrow from /implement to /ship -->
+  <line x1="460" y1="224" x2="460" y2="270" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Arrow from /ship to Draft PR -->
+  <line x1="460" y1="324" x2="460" y2="370" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ==================== REVIEW PHASE ==================== -->
+
+  <!-- /review command -->
+  <rect x="660" y="170" width="210" height="54" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="682" y="194" fill="#60a5fa" font-size="13" font-weight="700">/review</text>
+  <text x="682" y="212" fill="#94a3b8" font-size="10">Step-by-step PR walkthrough</text>
+
+  <!-- Arrow from Draft PR to /review -->
+  <path d="M565,395 Q612,395 660,197" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ==================== HUMAN CHECKPOINT 2 ==================== -->
+  <rect x="660" y="280" width="210" height="46" rx="23" fill="#451a03" stroke="#d97706" stroke-width="1.5"/>
+  <text x="765" y="300" fill="#fbbf24" font-size="11" font-weight="600" text-anchor="middle">HUMAN CHECKPOINT</text>
+  <text x="765" y="315" fill="#fcd34d" font-size="9" text-anchor="middle">Review PR &amp; decide</text>
+
+  <!-- Arrow from /review to checkpoint 2 -->
+  <line x1="765" y1="224" x2="765" y2="280" stroke="#d97706" stroke-width="1.5" marker-end="url(#arrow-amber)"/>
+
+  <!-- Decision: Merge or Address -->
+  <!-- Merge path -->
+  <rect x="700" y="370" width="130" height="40" rx="8" fill="#064e3b" stroke="#059669" stroke-width="1.5"/>
+  <text x="765" y="395" fill="#34d399" font-size="12" font-weight="600" text-anchor="middle">Merge</text>
+
+  <line x1="765" y1="326" x2="765" y2="370" stroke="#059669" stroke-width="1.5" marker-end="url(#arrow-emerald)"/>
+
+  <!-- /address command (feedback loop) -->
+  <rect x="660" y="450" width="210" height="54" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="682" y="474" fill="#fbbf24" font-size="13" font-weight="700">/address</text>
+  <text x="682" y="492" fill="#94a3b8" font-size="10">Fix review comments → update PR</text>
+
+  <!-- Arrow from checkpoint to /address -->
+  <path d="M832" y="326" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="860" y="348" fill="#94a3b8" font-size="9">changes</text>
+  <text x="860" y="360" fill="#94a3b8" font-size="9">needed</text>
+  <path d="M870,303 L890,303 L890,477 L870,477" fill="none" stroke="#f59e0b" stroke-width="1.5" marker-end="url(#arrow-amber)"/>
+
+  <!-- Arrow from /address back to /review (loop) -->
+  <path d="M660,477 L640,477 L640,197 L660,197" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ==================== REFLECT PHASE ==================== -->
+
+  <!-- /learn command -->
+  <rect x="955" y="170" width="210" height="54" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="977" y="194" fill="#34d399" font-size="13" font-weight="700">/learn</text>
+  <text x="977" y="212" fill="#94a3b8" font-size="10">Session insights → CLAUDE.md</text>
+
+  <!-- /knowledge command -->
+  <rect x="955" y="270" width="210" height="54" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="977" y="294" fill="#34d399" font-size="13" font-weight="700">/knowledge</text>
+  <text x="977" y="312" fill="#94a3b8" font-size="10">Learnings → Zettelkasten</text>
+
+  <!-- CLAUDE.md artifact -->
+  <rect x="990" y="370" width="140" height="40" rx="8" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="1060" y="395" fill="#c4b5fd" font-size="11" font-weight="600" text-anchor="middle">CLAUDE.md</text>
+
+  <!-- Zettelkasten artifact -->
+  <rect x="990" y="430" width="140" height="40" rx="8" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="1060" y="455" fill="#c4b5fd" font-size="11" font-weight="600" text-anchor="middle">Zettelkasten</text>
+
+  <!-- Arrow from Merge to /learn -->
+  <path d="M830,390 Q892,390 955,197" fill="none" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Arrow from /learn to /knowledge -->
+  <line x1="1060" y1="224" x2="1060" y2="270" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Arrow from /learn to CLAUDE.md -->
+  <path d="M1060,224 L1060,250 L1120,250 L1120,370" fill="none" stroke="#64748b" stroke-width="1" stroke-dasharray="4,4" marker-end="url(#arrow)"/>
+
+  <!-- Arrow from /knowledge to Zettelkasten -->
+  <path d="M1060,324 L1060,340 L1120,340 L1120,430" fill="none" stroke="#64748b" stroke-width="1" stroke-dasharray="4,4" marker-end="url(#arrow)"/>
+
+  <!-- ==================== DOCUMENTATION COMMANDS (bottom) ==================== -->
+
+  <rect x="50" y="565" width="1100" height="120" rx="10" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+  <text x="80" y="592" fill="#64748b" font-size="11" font-weight="600" letter-spacing="2">DOCUMENTATION COMMANDS</text>
+  <text x="80" y="610" fill="#475569" font-size="9">Run during admittance or when docs need updating. Not part of the per-issue workflow.</text>
+
+  <!-- /prd -->
+  <rect x="80" y="628" width="150" height="40" rx="6" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+  <text x="103" y="647" fill="#818cf8" font-size="12" font-weight="600">/prd</text>
+  <text x="103" y="661" fill="#94a3b8" font-size="9">→ docs/PRD.md</text>
+
+  <!-- /architecture -->
+  <rect x="260" y="628" width="200" height="40" rx="6" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+  <text x="283" y="647" fill="#818cf8" font-size="12" font-weight="600">/architecture</text>
+  <text x="283" y="661" fill="#94a3b8" font-size="9">→ docs/ARCHITECTURE.md</text>
+
+  <!-- /traceability -->
+  <rect x="490" y="628" width="200" height="40" rx="6" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+  <text x="513" y="647" fill="#818cf8" font-size="12" font-weight="600">/traceability</text>
+  <text x="513" y="661" fill="#94a3b8" font-size="9">→ docs/TRACEABILITY.md</text>
+
+  <!-- ==================== LEGEND ==================== -->
+  <rect x="780" y="628" width="340" height="40" rx="6" fill="none"/>
+
+  <!-- Legend items -->
+  <rect x="790" y="634" width="12" height="12" rx="2" fill="#1e293b" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="808" y="644" fill="#94a3b8" font-size="9">Agent command</text>
+
+  <rect x="900" y="634" width="12" height="12" rx="2" fill="#1e293b" stroke="#a78bfa" stroke-width="1.2"/>
+  <text x="918" y="644" fill="#94a3b8" font-size="9">Artifact</text>
+
+  <rect x="980" y="634" width="12" height="12" rx="6" fill="#451a03" stroke="#d97706" stroke-width="1.2"/>
+  <text x="998" y="644" fill="#94a3b8" font-size="9">Human checkpoint</text>
+
+  <rect x="790" y="654" width="12" height="12" rx="2" fill="#064e3b" stroke="#059669" stroke-width="1.2"/>
+  <text x="808" y="664" fill="#94a3b8" font-size="9">Gate passed</text>
+
+  <rect x="900" y="654" width="12" height="12" rx="2" fill="#1e293b" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="918" y="664" fill="#94a3b8" font-size="9">Feedback loop</text>
+
+  <rect x="980" y="654" width="12" height="12" rx="2" fill="#1e293b" stroke="#10b981" stroke-width="1.2"/>
+  <text x="998" y="664" fill="#94a3b8" font-size="9">Reflect (additive)</text>
+</svg>

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -28,7 +28,7 @@
 
 ## Governance
 
-This project is a Land in the federated governance framework. The constitution of the Federation is defined in the [CONSTITUTION.md](https://github.com/forketyfork/governance/blob/main/CONSTITUTION.md).
+This project is a Land in the federated governance framework. The constitution of the Federation is defined in the [CONSTITUTION.md](https://raw.githubusercontent.com/forketyfork/governance/refs/heads/main/CONSTITUTION.md).
 
 ## Project Documentation
 


### PR DESCRIPTION
## Summary

Batch of small fixes across governance docs and one enhancement to the `/learn` command.

## Changes

- `ADMITTANCE.md`: Two cross-references used the word "above" from back when the Registry of Lands and Standard Guardrails lived in the same file. They now point to CONSTITUTION.md and FEDERATION.md respectively.
- `templates/CLAUDE.md.template`: The CONSTITUTION.md link pointed to the GitHub blob (HTML) view. Switched to the raw content URL so agents consuming the template can fetch it directly.
- `commands/learn.md`: Added a deduplication check and a pruning step before the update-drafting section. The command now verifies whether CLAUDE.md already covers a topic before proposing additions, and actively reviews related entries for staleness.
- `images/workflow-diagram.svg`: Added workflow diagram asset.
- `README.md`: Embedded the workflow diagram at the top of the file.

Fixes #8, fixes #9, fixes #10.