### PR TITLE
fix(ship): use unique filename for PR body temp file

### DIFF
--- a/commands/ship.md
+++ b/commands/ship.md
@@ -24,7 +24,7 @@ After confirmation:
   ```
 
 - Use the **humanizer** skill on the PR body before creating the PR
-- Write the PR body to `.tmp/pr-body.md`, then create the PR using `gh pr create --body-file .tmp/pr-body.md`:
+- Write the PR body to `.tmp/pr-body-$RANDOM.md` (use a unique filename), then create the PR using `gh pr create --body-file <path>`:
   - Title matching the commit's short description
   - Body containing the Solution section expanded with context for reviewers
   - Link to relevant issues if mentioned in session


### PR DESCRIPTION
## Summary

The `/ship` skill hardcoded `.tmp/pr-body.md` as the temp file path. This conflicts with the CLAUDE.md rule that temp files should use unique names (via `$RANDOM` or timestamps) to avoid the Write tool failing on files that haven't been read yet.

Changed the instruction to use `.tmp/pr-body-$RANDOM.md` and made it explicit that unique filenames are expected.