### PR TITLE
Require reproducible Land dev environments (fixes #21)

### DIFF
--- a/ADMITTANCE.md
+++ b/ADMITTANCE.md
@@ -19,8 +19,12 @@ Not every project needs governance. If it's a throwaway experiment, a one-off sc
    - Create pre-commit hooks that run lint + format + type check + test.
    - Set up CI (GitHub Actions recommended) with build + test + lint.
    - Enable branch protection on main/master.
-4. **Create the `docs/` directory.**
-5. **Assess observability:**
+4. **Set up a reproducible development environment:**
+   - Configure a stack-appropriate environment activation path from inside the repository (for example, Nix + direnv, devcontainer, virtual environment).
+   - Keep host prerequisites minimal and document them explicitly.
+   - Verify that build, lint, type-check, and test commands run after environment activation without undeclared global dependencies.
+5. **Create the `docs/` directory.**
+6. **Assess observability:**
    - Can the agent run the project and see output? If not, create a run/start script.
    - Can the agent run tests and see results? If not, configure the test runner for CLI output.
    - Can the agent read logs? Document log locations and how to enable debug logging.
@@ -65,5 +69,7 @@ A Land reaches `Governed` status when ALL of the following are true:
 - [ ] CI pipeline runs build + test + lint on every push
 - [ ] Branch protection enabled on main/master
 - [ ] Pre-commit hooks installed and working
+- [ ] Reproducible development environment is documented in CLAUDE.md with activation steps and minimal host prerequisites
+- [ ] After activation, build/lint/type-check/test commands run without undeclared global setup
 - [ ] CLAUDE.md includes an Observability section (what the agent can do independently, what requires developer assistance, debug mode)
 - [ ] Cross-Land dependencies recorded in FEDERATION.md dependency map (if applicable)

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -127,6 +127,23 @@ Every documented convention is a candidate for automation. Promotion is the proc
 
 Each Land must minimize the developer-as-relay bottleneck. The goal: the agent should never ask for something it could have obtained itself if the project were properly configured.
 
+### Reproducible Development Environment
+
+Each Land must provide a reproducible development environment that can be
+activated from within the project directory. The mechanism is stack-specific
+and may use any appropriate toolchain (for example, Nix + direnv,
+devcontainers, virtual environments), but the outcome is mandatory:
+
+- The activation path is documented in the Land's CLAUDE.md.
+- Required host prerequisites are minimal and explicitly documented.
+- Build, lint, type-check, and test workflows run without hidden global setup.
+- Setup instructions are deterministic enough for both the developer and the
+  agent to follow without project-external tribal knowledge.
+
+This is an outcome requirement, not a tool mandate. A Land is compliant when a
+new machine with the documented prerequisites can enter the repository, run the
+documented activation path, and execute the Land's standard workflows.
+
 ### Observability
 
 Each Land's CLAUDE.md must include an **Observability** section documenting:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -61,6 +61,11 @@ guardrails, structured workflows, and human checkpoints that prevent that rot.
     in `FEDERATION.md` and a mandatory review step that blocks merging until the
     assessment is complete.
 
+12. **F12: Reproducible Development Environment Requirement** — A governance
+    requirement that each Land defines a stack-appropriate, repo-local
+    environment activation path with minimal host prerequisites, so development
+    workflows run without hidden machine-specific setup.
+
 ## Non-Goals
 
 - **Code generation.** The governance framework defines workflows and
@@ -216,6 +221,18 @@ quality, with full documentation created retroactively.
 **Result:** Contract changes never silently break dependent Lands. Every
 cross-Land impact is assessed, documented, and tracked before merging.
 
+### F12: Reproducible Development Environment Requirement
+
+1. Developer enters a Land repository and reads environment activation steps in
+   that Land's `CLAUDE.md`.
+2. Developer activates the stack-appropriate development environment from inside
+   the repository.
+3. Developer and agent run build, lint, type-check, and test workflows without
+   relying on undeclared global machine setup.
+
+**Result:** Environment setup is repeatable and Land-local, reducing setup drift
+and hidden dependencies.
+
 ## Success Criteria
 
 - **F1:** The constitution covers principles, separation of powers, standard
@@ -248,3 +265,6 @@ cross-Land impact is assessed, documented, and tracked before merging.
   source Land, contract, type, and consuming Land. `/review` includes a
   cross-Land impact step that checks contract changes against the dependency
   map.
+- **F12:** The constitution and admittance process require each Land to document
+  and validate a reproducible, repo-local development environment with minimal
+  host prerequisites and a clear activation path.

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -10,6 +10,13 @@
 ## Build & Run
 
 ```bash
+# Environment activation
+[environment activation command]
+#
+# Minimal host prerequisites:
+# - [prerequisite 1]
+# - [prerequisite 2]
+
 # Build
 [build command]
 


### PR DESCRIPTION
## Summary

This PR adds a federation-level requirement that each Land provide a reproducible development environment that can be activated from within the repository using stack-appropriate tooling. It updates governance policy, admittance criteria, and Land bootstrap template guidance so the requirement is explicit, verifiable, and tool-agnostic.

## Changes

- `CONSTITUTION.md`: added a new "Reproducible Development Environment" subsection under Agent Environment with normative requirements and compliance criteria.
- `ADMITTANCE.md`: added Phase 1 setup steps and Governed checklist items for reproducible environment setup and verification.
- `templates/CLAUDE.md.template`: added explicit environment activation and minimal host prerequisite placeholders in the Build & Run section.
- `docs/PRD.md`: added F12 (Reproducible Development Environment Requirement), its user flow, and success criterion coverage.

### For Features

**New behavior:** Governance now requires each Land to document and provide a reproducible, repo-local environment activation path with minimal host prerequisites so standard workflows run without hidden global setup.
**Docs updated:** `docs/PRD.md`

## Checklist

- [ ] All tasks from the issue are completed
- [ ] Tests added/updated
- [x] All pre-commit hooks pass
- [x] All existing tests still pass
- [x] No new TODOs in code
- [x] No new dependencies (or explicitly approved)
- [x] Docs updated (PRD / ARCHITECTURE / TRACEABILITY as applicable)
- [x] Commit messages follow conventional commits

Unmet acceptance criterion from issue #21: `docs/TRACEABILITY.md` was not updated because the repository currently does not maintain tests and this was explicitly requested in this session.

## Manual Steps Required

None
