### PR TITLE
Require worktree-ready setup for Land admittance (fixes #23)

### DIFF
--- a/ADMITTANCE.md
+++ b/ADMITTANCE.md
@@ -19,10 +19,11 @@ Not every project needs governance. If it's a throwaway experiment, a one-off sc
    - Create pre-commit hooks that run lint + format + type check + test.
    - Set up CI (GitHub Actions recommended) with build + test + lint.
    - Enable branch protection on main/master.
-4. **Set up a reproducible development environment:**
+4. **Set up a reproducible, worktree-ready development environment:**
    - Configure a stack-appropriate environment activation path from inside the repository (for example, Nix + direnv, devcontainer, virtual environment).
+   - Define a worktree bootstrap entry point at the repository root (prefer `script/setup` following scripts-to-rule-them-all, or a clearly documented equivalent command).
    - Keep host prerequisites minimal and document them explicitly.
-   - Verify that build, lint, type-check, and test commands run after environment activation without undeclared global dependencies.
+   - Verify that from a fresh git worktree, bootstrap + activation can run build, lint, type-check, and test without undeclared global dependencies or setup performed in another worktree.
 5. **Create the `docs/` directory.**
 6. **Assess observability:**
    - Can the agent run the project and see output? If not, create a run/start script.
@@ -69,7 +70,7 @@ A Land reaches `Governed` status when ALL of the following are true:
 - [ ] CI pipeline runs build + test + lint on every push
 - [ ] Branch protection enabled on main/master
 - [ ] Pre-commit hooks installed and working
-- [ ] Reproducible development environment is documented in CLAUDE.md with activation steps and minimal host prerequisites
-- [ ] After activation, build/lint/type-check/test commands run without undeclared global setup
+- [ ] Reproducible development environment is documented in CLAUDE.md with activation steps, a worktree bootstrap entry point (`script/setup` preferred), and minimal host prerequisites
+- [ ] From a fresh git worktree, bootstrap + activation can run build/lint/type-check/test without undeclared global setup or reliance on sibling worktrees
 - [ ] CLAUDE.md includes an Observability section (what the agent can do independently, what requires developer assistance, debug mode)
 - [ ] Cross-Land dependencies recorded in FEDERATION.md dependency map (if applicable)

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -135,14 +135,20 @@ and may use any appropriate toolchain (for example, Nix + direnv,
 devcontainers, virtual environments), but the outcome is mandatory:
 
 - The activation path is documented in the Land's CLAUDE.md.
+- A worktree bootstrap entry point is documented (prefer `script/setup` per
+  scripts-to-rule-them-all, or a clearly documented equivalent command).
 - Required host prerequisites are minimal and explicitly documented.
 - Build, lint, type-check, and test workflows run without hidden global setup.
+- A fresh git worktree can run bootstrap + activation and then execute build,
+  lint, type-check, and test workflows without relying on setup performed in
+  other worktrees.
 - Setup instructions are deterministic enough for both the developer and the
   agent to follow without project-external tribal knowledge.
 
 This is an outcome requirement, not a tool mandate. A Land is compliant when a
-new machine with the documented prerequisites can enter the repository, run the
-documented activation path, and execute the Land's standard workflows.
+new machine with the documented prerequisites can enter a fresh worktree, run
+the documented bootstrap and activation paths, and execute the Land's standard
+workflows.
 
 ### Observability
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -63,8 +63,9 @@ guardrails, structured workflows, and human checkpoints that prevent that rot.
 
 12. **F12: Reproducible Development Environment Requirement** — A governance
     requirement that each Land defines a stack-appropriate, repo-local
-    environment activation path with minimal host prerequisites, so development
-    workflows run without hidden machine-specific setup.
+    environment activation path and a worktree bootstrap entry point (prefer
+    `script/setup` or an equivalent command), with minimal host prerequisites,
+    so development workflows run without hidden machine-specific setup.
 
 ## Non-Goals
 
@@ -224,14 +225,16 @@ cross-Land impact is assessed, documented, and tracked before merging.
 ### F12: Reproducible Development Environment Requirement
 
 1. Developer enters a Land repository and reads environment activation steps in
-   that Land's `CLAUDE.md`.
-2. Developer activates the stack-appropriate development environment from inside
-   the repository.
+   that Land's `CLAUDE.md`, including the worktree bootstrap command.
+2. Developer initializes a fresh git worktree, runs the documented bootstrap
+   entry point, and activates the stack-appropriate development environment from
+   inside that worktree.
 3. Developer and agent run build, lint, type-check, and test workflows without
-   relying on undeclared global machine setup.
+   relying on undeclared global machine setup or prior setup in other
+   worktrees.
 
-**Result:** Environment setup is repeatable and Land-local, reducing setup drift
-and hidden dependencies.
+**Result:** Environment setup is repeatable for each worktree, reducing setup
+drift and hidden dependencies.
 
 ## Success Criteria
 
@@ -266,5 +269,6 @@ and hidden dependencies.
   cross-Land impact step that checks contract changes against the dependency
   map.
 - **F12:** The constitution and admittance process require each Land to document
-  and validate a reproducible, repo-local development environment with minimal
-  host prerequisites and a clear activation path.
+  and validate a reproducible, worktree-ready development environment with
+  minimal host prerequisites, a clear activation path, and a documented
+  bootstrap entry point (`script/setup` preferred).


### PR DESCRIPTION
## Summary

This PR updates governance policy documents to make worktree-ready setup a hard admittance prerequisite for Lands. It extends the existing reproducible-environment requirement to include a documented bootstrap entry point (`script/setup` preferred) and explicit validation from a fresh git worktree.

## Changes

- `CONSTITUTION.md`: Expanded the Reproducible Development Environment section to require a documented worktree bootstrap entry point and fresh-worktree validation for standard workflows.
- `ADMITTANCE.md`: Updated Phase 1 foundation requirements and Governed checklist to include worktree bootstrap and fresh-worktree verification.
- `docs/PRD.md`: Updated F12 feature definition, user flow, and success criteria to reflect worktree-ready setup requirements.

### For Features

**New behavior:** Admittance policy now requires each Land to document and validate worktree-ready setup, including a bootstrap command and successful workflow execution from a fresh worktree.
**Docs updated:** `docs/PRD.md`

## Checklist

- [ ] All tasks from the issue are completed
- [ ] Tests added/updated
- [ ] All pre-commit hooks pass
- [ ] All existing tests still pass
- [ ] No new TODOs in code
- [ ] No new dependencies (or explicitly approved)
- [ ] Docs updated (PRD / ARCHITECTURE / TRACEABILITY as applicable)
- [ ] Commit messages follow conventional commits

## Manual Steps Required

None
