### PR TITLE
fix(commands): guard dependency-direction check on ARCHITECTURE.md presence

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -42,7 +42,7 @@ Ask: "Any of these surprise you?"
 ### Step 3: Architecture Conformance
 
 - Is new code in the correct module per docs/ARCHITECTURE.md (if present)?
-- Any new cross-module dependencies? Do they match the documented dependency direction?
+- Any new cross-module dependencies? If docs/ARCHITECTURE.md exists, do they match the documented dependency direction?
 - Any circular dependencies?
 - If architecture changed and docs/ARCHITECTURE.md exists: is it updated?
 


### PR DESCRIPTION
## Summary

PR #31 qualified most doc references in `/review` with "if present" guards, but missed one bullet in Step 3 (Architecture Conformance). The dependency-direction check still unconditionally asks whether new cross-module dependencies "match the documented dependency direction" — which has no source of truth when `docs/ARCHITECTURE.md` doesn't exist. This adds the missing guard, consistent with the other bullets in the same step.

## Changes

- `commands/review.md`: qualified the cross-module dependency direction check with "If docs/ARCHITECTURE.md exists"

## Checklist

- [x] All pre-commit hooks pass
- [x] No new TODOs in code
- [x] No new dependencies

## Manual Steps Required

None
