### PR TITLE
fix(commands): direct auto-close keywords to PR body instead of title (#33)

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -116,7 +116,8 @@ When implementation is complete, create a draft PR with this format:
 
 ## Critical Constraints
 
-- The PR title MUST clearly reference the issue number. Where supported by the hosting platform, include an auto-close keyword (e.g., "fixes #<number>"). On platforms without auto-close, include the issue reference for traceability (e.g., "#<number>").
+- The PR title MUST reference the issue number for traceability (e.g., `<concise description> (#<number>)`).
+- Where supported by the hosting platform, include an auto-close keyword in the PR **body** (e.g., "Fixes #<number>"). On platforms without auto-close, include the issue reference in the body for traceability.
 - The PR is DRAFT. Do not mark it ready for review. The user decides.
 - If you cannot meet all acceptance criteria, state which ones are unmet and why.
 - If you notice something else that should be fixed, suggest a separate issue. Do NOT fix it in this PR.

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -25,8 +25,8 @@ After confirmation:
 
 - Use the **humanizer** skill on the PR body before creating the PR
 - Write the PR body to `.tmp/pr-body-$RANDOM.md` (use a unique filename), then create the PR **as a draft** (or the hosting platform's equivalent draft/WIP state) using the pull request CLI or API for the source code hosting declared in the project's CLAUDE.md:
-  - Title matching the commit's short description
+  - Title matching the commit's short description, with the issue number for traceability (e.g., `<description> (#<number>)`)
   - Body containing the Solution section expanded with context for reviewers
-  - Link to relevant issues if mentioned in session
+  - Where supported by the hosting platform, include an auto-close keyword in the body (e.g., "Fixes #<number>") to link and close the relevant issue on merge
 
 Show me the PR link when done.


### PR DESCRIPTION
## Summary

The `implement` and `ship` command specs told agents to put auto-close keywords (like "fixes #N") in the PR title. GitHub only recognizes those keywords in the PR body or commit messages, so linked issues weren't getting closed on merge.

Both specs now separate the two concerns: the title carries the issue number for traceability (`(#N)` suffix), and auto-close keywords go in the body where GitHub actually acts on them.

## Changes

- `commands/implement.md`: Split the single "Critical Constraints" bullet into two — one for the title format (traceability only), one directing auto-close keywords to the PR body.
- `commands/ship.md`: Updated PR creation instructions to include the issue number in the title and place auto-close keywords in the body.

### Bug details

**Root cause:** The implement command spec's "Critical Constraints" section instructed agents to put auto-close keywords in the PR title, where GitHub ignores them.
**Fix:** Separated title formatting (issue number for traceability) from auto-close behavior (keywords in the body).
**Regression test:** N/A — documentation-only repository with no test suite.

## Checklist

- [x] All tasks from the issue are completed
- [x] Tests added/updated (N/A — docs-only repo)
- [x] All pre-commit hooks pass
- [x] All existing tests still pass (N/A)
- [x] No new TODOs in code
- [x] No new dependencies
- [x] Docs updated (command specs updated)
- [x] Commit messages follow conventional commits

## Manual steps required

Re-run `./scripts/install-commands.sh` in any Land that installed command symlinks, so the updated specs take effect.

Fixes #33
