### PR TITLE
feat(ship): add optional manual test plan section to PR body (#50)

### DIFF
--- a/commands/ship.md
+++ b/commands/ship.md
@@ -28,7 +28,9 @@ After confirmation:
 - Apply the **humanizer** skill to the PR body internally — do not output the humanized text or pause for confirmation, just use the result when creating the PR and continue
 - Write the PR body to `.tmp/pr-body-$RANDOM.md` (use a unique filename), then create the PR **as a draft** (or the hosting platform's equivalent draft/WIP state) using the pull request CLI or API for the source code hosting declared in the project's CLAUDE.md:
   - Title matching the commit's short description, plus any issue-linkage markers required by the project's documented issue/PR linkage convention in CLAUDE.md
-  - Body containing the Solution section expanded with context for reviewers, plus the issue-linkage fields/keywords/URLs required by CLAUDE.md
+  - Body containing:
+    - The Solution section expanded with context for reviewers, plus the issue-linkage fields/keywords/URLs required by CLAUDE.md
+    - A **Test plan** section with a checklist of manual verification steps the reviewer should perform. Only include steps that require human judgment or interaction — exclude anything already verified by automated tests, linters, type checkers, or CI. If the change is fully covered by automation, omit this section entirely.
   - For hotfix fast-path work where no issue exists yet, omit issue linkage and note that linkage will be added during mandatory cleanup
 
 Show me the PR link when done.


### PR DESCRIPTION
## Summary

PR descriptions created by `/ship` had no guidance for manual testing. Reviewers had to figure out on their own what needed hands-on verification beyond what CI, tests, and linters already cover.

This adds a **Test plan** section to the `/ship` PR body instructions. The agent now includes a checklist of manual verification steps that require human judgment or interaction, explicitly excluding anything already covered by automated checks. When the change is fully covered by automation, the section is omitted entirely — no empty headings or placeholder text.

Fixes #50

## Test plan

- [ ] Run `/ship` on a change that has manual verification steps and confirm the PR body includes a Test plan section
- [ ] Run `/ship` on a change fully covered by automation and confirm the Test plan section is absent
