### PR TITLE
feat(template): add agent rule to verify build and tests pass

### DIFF
--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -71,6 +71,7 @@ Read these before making any changes:
 6. If you change the architecture (new modules, new data flows), update `docs/ARCHITECTURE.md`.
 7. If you add a feature, update `docs/TRACEABILITY.md`.
 8. Use conventional commit messages.
+9. After making changes, verify the build, tests, and linting all pass before considering the task done.
 
 ## Observability
 


### PR DESCRIPTION
## Summary

The template CLAUDE.md had no rule telling agents to run the build, tests, and linting after making changes. Agents were expected to do this, but nowhere was it written down.

Added rule 9 to the Agent Rules section: agents must verify the build, tests, and linting pass before considering a task done. Any project adopting the template now has this spelled out explicitly.