### PR TITLE
docs(commands): add frontmatter and replace gh CLI with skill references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ shfmt -d scripts/*.sh
 
 ## Infrastructure
 
-- **Source code hosting:** GitHub — URL: `https://github.com/forketyfork/governance` — CLI: `gh`
-- **Issue tracker:** GitHub Issues — URL: `https://github.com/forketyfork/governance/issues` — CLI: `gh issue`
+- **Source code hosting:** GitHub — URL: `https://github.com/forketyfork/governance` — Skill: `managing-github`
+- **Issue tracker:** GitHub Issues — URL: `https://github.com/forketyfork/governance/issues` — Skill: `managing-github`
 - **CI/CD:** GitHub Actions — config: `.github/workflows/build.yml`
 - **Issue/PR linkage convention:** For issue-driven work, include the issue number in the PR title as `(#<number>)` and add `Fixes #<number>` in the PR body. For hotfixes without an issue, omit linkage first and add it after creating the retroactive issue.
 
@@ -79,8 +79,8 @@ Read these before making any changes:
 
 - Run repository checks (`pre-commit run --all-files`, `nix flake check`)
 - Run markdown and shell quality tools directly
-- Create and update issues and pull requests via `gh`
-- Inspect CI workflow runs and logs via `gh`
+- Create and update issues and pull requests via the `managing-github` skill
+- Inspect CI workflow runs and logs via the `managing-github` skill
 
 ### What requires developer assistance
 

--- a/commands/address.md
+++ b/commands/address.md
@@ -1,5 +1,7 @@
 ---
+name: address
 description: "Address the PR review and issue comments"
+disable-model-invocation: true
 ---
 
 Review the **unresolved** review and issue comments on this PR against the PR description and our session context.

--- a/commands/amend.md
+++ b/commands/amend.md
@@ -1,3 +1,9 @@
+---
+name: amend
+description: "Propose a governance amendment from a project-level insight"
+disable-model-invocation: true
+---
+
 You are in AMENDMENT mode.
 
 Your job: take an insight from a project-level review or session and propose a change to the federation governance repository. You do NOT modify project files.

--- a/commands/architecture.md
+++ b/commands/architecture.md
@@ -1,3 +1,9 @@
+---
+name: architecture
+description: "Create or update the architecture documentation"
+disable-model-invocation: true
+---
+
 You are in ARCHITECTURE DOCUMENTATION mode.
 
 Your job: create or update docs/ARCHITECTURE.md for this project. Read the entire codebase first, then produce or revise the document.

--- a/commands/bug.md
+++ b/commands/bug.md
@@ -1,3 +1,9 @@
+---
+name: bug
+description: "Interview about a bug and produce an issue"
+disable-model-invocation: true
+---
+
 You are in BUG TRIAGE mode.
 
 Your job: interview the user about a bug and produce an issue. You do NOT write code. You do NOT suggest fixes.

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -1,3 +1,9 @@
+---
+name: feature
+description: "Interview about a feature and produce an issue with an implementation plan"
+disable-model-invocation: true
+---
+
 You are in FEATURE PLANNING mode.
 
 Your job: interview the user about a feature they want and produce an issue with an implementation plan. You do NOT write code.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,3 +1,9 @@
+---
+name: implement
+description: "Implement a specific issue and prepare draft PR content"
+disable-model-invocation: true
+---
+
 You are in IMPLEMENTATION mode.
 
 Your job: implement a specific issue and prepare draft Pull Request content for `/ship`. You work methodically, follow the project's conventions, and never go beyond the issue's scope.

--- a/commands/knowledge.md
+++ b/commands/knowledge.md
@@ -1,4 +1,5 @@
 ---
+name: knowledge
 description: "Produce learning notes for the developer from the coding session"
 ---
 

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,4 +1,5 @@
 ---
+name: learn
 description: "Extract learnings from sessions to update CLAUDE.md"
 ---
 

--- a/commands/prd.md
+++ b/commands/prd.md
@@ -1,3 +1,9 @@
+---
+name: prd
+description: "Create or update the product requirements document"
+disable-model-invocation: true
+---
+
 You are in PRD DOCUMENTATION mode.
 
 Your job: create or update docs/PRD.md for this project by reverse-engineering the product from the codebase and interviewing the user for intent. For greenfield projects, use interview-first mode.

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,3 +1,9 @@
+---
+name: review
+description: "Walk through reviewing a Pull Request"
+disable-model-invocation: true
+---
+
 You are in REVIEW GUIDE mode.
 
 Your job: walk the user through reviewing a Pull Request. You are NOT the author. You are a critical reviewer helping the user — who may not be fluent in this language — understand and evaluate the changes.
@@ -45,6 +51,7 @@ Ask: "Any of these surprise you?"
 - Any new cross-module dependencies? If docs/ARCHITECTURE.md exists, do they match the documented dependency direction?
 - Any circular dependencies?
 - If architecture changed and docs/ARCHITECTURE.md exists: is it updated?
+- If the PR introduces a significant architectural decision (new layer, new pattern, new external dependency, change to concurrency model, new communication protocol, etc.): is a new ADR present in docs/ARCHITECTURE.md? If not, flag it and suggest the author add one.
 
 If there's architectural drift, be explicit about it.
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,4 +1,5 @@
 ---
+name: ship
 description: "Preparing and shipping code changes"
 ---
 

--- a/commands/tech.md
+++ b/commands/tech.md
@@ -1,3 +1,9 @@
+---
+name: tech
+description: "Interview about technical debt and produce an issue"
+disable-model-invocation: true
+---
+
 You are in TECH DEBT mode.
 
 Your job: interview the user about a technical improvement and produce an issue. You do NOT write code.

--- a/commands/traceability.md
+++ b/commands/traceability.md
@@ -1,3 +1,9 @@
+---
+name: traceability
+description: "Create or update the traceability matrix"
+disable-model-invocation: true
+---
+
 You are in TRACEABILITY MATRIX mode.
 
 Your job: create or update docs/TRACEABILITY.md by mapping features from docs/PRD.md to their corresponding tests.

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -43,8 +43,8 @@
 
 ## Infrastructure
 
-- **Source code hosting:** [e.g., GitHub — URL: `https://github.com/org/repo` — CLI: `gh`]
-- **Issue tracker:** [e.g., GitHub Issues — URL: `https://github.com/org/repo/issues` — CLI: `gh issue`]
+- **Source code hosting:** [e.g., GitHub — URL: `https://github.com/org/repo` — Skill: `managing-github`]
+- **Issue tracker:** [e.g., GitHub Issues — URL: `https://github.com/org/repo/issues` — Skill: `managing-github`; or YouTrack — URL: `https://youtrack.example.com/project` — Skill: `managing-youtrack`]
 - **CI/CD:** [e.g., GitHub Actions — config: `.github/workflows/ci.yml`]
 - **Issue/PR linkage convention:** [Exact traceability rule for this Land. Include title markers, body keywords, tracker links/fields, auto-close behavior if supported, and fallback if source hosting and issue tracker are different.]
 


### PR DESCRIPTION
Two changes on this branch.

The first commit adds `name` and `description` to all 13 command frontmatters. Nine mode-setting commands got `disable-model-invocation: true` — `address` in particular was firing automatically when the model pattern-matched on context (e.g., seeing PR review comments) instead of waiting for an explicit user invocation. `ship`, `learn`, and `knowledge` stay model-invokable. The `review` command also gained a check in its architecture conformance step: if a PR introduces a significant architectural decision with no corresponding ADR, flag it.

The second commit updates `CLAUDE.md` and `templates/CLAUDE.md.template` to point agents to the `managing-github` skill for GitHub operations instead of the raw `gh` CLI. The template's issue tracker example now shows both `managing-github` (GitHub Issues) and `managing-youtrack` (YouTrack) as options.
