### PR TITLE
fix(ship): clarify PR creation method and temp filename generation (#59)

### DIFF
--- a/commands/ship.md
+++ b/commands/ship.md
@@ -27,7 +27,7 @@ After confirmation:
   ```
 
 - Apply the **humanizer** skill to the PR body internally — do not output the humanized text or pause for confirmation, just use the result when creating the PR and continue
-- Write the PR body to `.tmp/pr-body-$RANDOM.md` (use a unique filename), then create the PR **as a draft** (or the hosting platform's equivalent draft/WIP state) using the pull request CLI or API for the source code hosting declared in the project's CLAUDE.md:
+- Run `date +%s` to get a timestamp, write the PR body to `.tmp/pr-body-<timestamp>.md` using that value as a concrete filename, then create the PR **as a draft** (or the hosting platform's equivalent draft/WIP state) using the PR management skill declared in the project's CLAUDE.md:
   - If a PR already exists for the branch, **adjust** its title/body if needed to incorporate the new changes while preserving existing context. Do **not** overwrite the title/body with only the current session's text.
   - Title matching the commit's short description, plus any issue-linkage markers required by the project's documented issue/PR linkage convention in CLAUDE.md
   - Body containing:


### PR DESCRIPTION
Two wording bugs in `commands/ship.md` caused agents to go off-script. The phrase "pull request CLI or API" was vague enough that agents defaulted to `gh pr create` rather than checking what the project's `CLAUDE.md` actually declared. Separately, the `$RANDOM` variable in the suggested temp filename path got interpreted literally — so agents created a file named `pr-body-$RANDOM.md` and then couldn't find it.

Both are fixed in a single line change. The filename instruction now tells agents to run `date +%s` first and use the result as a concrete value. The PR creation instruction now says "PR management skill declared in the project's CLAUDE.md", which leaves no ambiguity about where to look.

Fixes #59
