### PR TITLE
fix: materialize codex skills during install

### DIFF
--- a/.agents/skills/address/agents/openai.yaml
+++ b/.agents/skills/address/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Address"
+  short_description: "Address review and issue comments"
+  default_prompt: "Use $address to summarize the unresolved review and issue comments on this PR and prepare the follow-up work."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/amend/agents/openai.yaml
+++ b/.agents/skills/amend/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Amend"
+  short_description: "Propose a governance amendment"
+  default_prompt: "Use $amend to turn this governance insight into a proposed amendment with the right supporting updates."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/architecture/agents/openai.yaml
+++ b/.agents/skills/architecture/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Architecture"
+  short_description: "Create or update architecture docs"
+  default_prompt: "Use $architecture to create or update docs/ARCHITECTURE.md for this project."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/bug/agents/openai.yaml
+++ b/.agents/skills/bug/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Bug"
+  short_description: "Interview and draft a bug issue"
+  default_prompt: "Use $bug to interview me about a bug and draft the issue."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/feature/agents/openai.yaml
+++ b/.agents/skills/feature/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Feature"
+  short_description: "Interview and plan a feature issue"
+  default_prompt: "Use $feature to interview me about a feature and draft the issue with an implementation plan."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/implement/agents/openai.yaml
+++ b/.agents/skills/implement/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Implement"
+  short_description: "Implement an issue methodically"
+  default_prompt: "Use $implement to work through this issue and prepare draft PR content."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/knowledge/agents/openai.yaml
+++ b/.agents/skills/knowledge/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Knowledge"
+  short_description: "Write developer learning notes"
+  default_prompt: "Use $knowledge to turn this coding session into concise developer learning notes."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/learn/agents/openai.yaml
+++ b/.agents/skills/learn/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Learn"
+  short_description: "Extract learnings into CLAUDE.md"
+  default_prompt: "Use $learn to extract the durable learnings from this session and update CLAUDE.md."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/prd/agents/openai.yaml
+++ b/.agents/skills/prd/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "PRD"
+  short_description: "Create or update the PRD"
+  default_prompt: "Use $prd to create or update docs/PRD.md for this project."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/review/agents/openai.yaml
+++ b/.agents/skills/review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Review"
+  short_description: "Walk through reviewing a PR"
+  default_prompt: "Use $review to walk me through reviewing this pull request."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/ship/agents/openai.yaml
+++ b/.agents/skills/ship/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Ship"
+  short_description: "Prepare and ship code changes"
+  default_prompt: "Use $ship to prepare the current changes for commit, push, and a draft PR."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/tech/agents/openai.yaml
+++ b/.agents/skills/tech/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Tech"
+  short_description: "Interview and draft a tech issue"
+  default_prompt: "Use $tech to interview me about technical debt and draft the issue."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/traceability/agents/openai.yaml
+++ b/.agents/skills/traceability/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Traceability"
+  short_description: "Create or update traceability docs"
+  default_prompt: "Use $traceability to create or update docs/TRACEABILITY.md for this project."
+
+policy:
+  allow_implicit_invocation: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Canonical file: `CLAUDE.md`. Keep `AGENTS.md` as a symlink to `CLAUDE.md`.
 ## Project
 
 **Name:** governance  
-**Description:** Shared command specs, templates, and process documentation for AI-assisted software projects. This repository defines the baseline workflow and standards that other projects can adopt.  
+**Description:** Shared command specs, Codex skill metadata, templates, and process documentation for AI-assisted software projects. This repository defines the baseline workflow and standards that other projects can adopt.  
 **Stack:** Markdown, Bash, Nix, GitHub Actions  
 **Status:** Active development
 
@@ -52,7 +52,7 @@ shfmt -d scripts/*.sh
 
 ## Governance
 
-This repository is the source of command and process guidance. During day-to-day work in other repositories, commands must rely only on that target repository's local `CLAUDE.md`/`AGENTS.md` and local docs.
+This repository is the source of command, skill, and process guidance. During day-to-day work in other repositories, commands must rely only on that target repository's local `CLAUDE.md`/`AGENTS.md` and local docs.
 
 ## Project Documentation
 
@@ -95,6 +95,6 @@ Read these before making any changes:
 
 ## Project-Specific Notes
 
-- `scripts/install-commands.sh` creates symlinks; it does not copy command files.
-- Changes in `commands/` affect agent behavior across projects that consume these command specs.
+- `scripts/install-commands.sh` creates symlinks for Claude command files and materializes Codex skill directories with a real `SKILL.md`.
+- Changes in `commands/` affect the Claude command install immediately and the installed Codex `SKILL.md` immediately when hard links are used, otherwise on the next install. Changes in `.agents/skills/*` affect Codex-only metadata and support files on the next install.
 - Keep temporary files in `.tmp/` with unique names.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,21 @@ The core idea: standardized documentation, mandatory automated checks, structure
 
 ## Quick Start
 
-### Install Agent Commands
+### Install Agent Workflows
 
-The `install-commands.sh` script symlinks command specifications to your Claude Code and Codex configuration directories:
+The `install-commands.sh` script symlinks Claude command specs to
+`~/.claude/commands/` and materializes Codex skills under `~/.agents/skills/`:
 
 ```bash
 ./scripts/install-commands.sh
 ```
 
-Changes to files in `commands/` take effect immediately across all tools that consumed the symlinks.
+Changes to files in `commands/` take effect immediately in Claude Code. For
+Codex, the installer writes a real `SKILL.md` for each installed skill because
+Codex does not load symlinked `SKILL.md` files. The installer hard-links files
+when possible and falls back to copying them when it cannot. Invoke the
+installed workflows in Codex as skills such as `$feature`, `$review`, or
+`$ship`.
 
 ### Set Up Development Environment
 
@@ -51,6 +57,8 @@ governance/
 ├── ADMITTANCE.md               # How to admit a new Land
 ├── CLAUDE.md                   # Agent instructions for this repo
 ├── README.md                   # This file
+├── .agents/
+│   └── skills/                 # Codex metadata and support files for installed skills
 ├── commands/                   # Agent command specifications
 │   ├── address.md
 │   ├── amend.md
@@ -97,7 +105,21 @@ Every Land maintains these in a `docs/` directory:
 
 ### Agent Commands
 
-The `commands/` directory contains specifications for agent commands that structure the development workflow. Documentation commands (`/prd`, `/architecture`, `/traceability`) create and maintain the standard documents. Delivery commands (`/bug`, `/feature`, `/tech`, `/implement`, `/ship`, `/review`, `/address`) handle planning through review. Session commands (`/learn`, `/knowledge`) capture reusable learning, and governance commands (`/amend`) evolve the framework. Platform-specific operational procedures are provided through dedicated skills (for example the `managing-github` skill in the [`forketyfork/agentic-skills`](https://github.com/forketyfork/agentic-skills) GitHub repository).
+The `commands/` directory contains the canonical workflow specifications.
+Claude Code consumes those files directly as slash commands. Codex consumes
+materialized skills in `~/.agents/skills/`. The repository keeps Codex-specific
+metadata and support files in `.agents/skills/`, and
+`install-commands.sh` combines those files with the corresponding
+`commands/*.md` body to build each installed skill.
+Documentation commands (`/prd`, `/architecture`, `/traceability`) create and
+maintain the standard documents. Delivery commands (`/bug`, `/feature`, `/tech`,
+`/implement`, `/ship`, `/review`, `/address`) handle planning through review.
+Session commands (`/learn`, `/knowledge`) capture reusable learning, and
+governance commands (`/amend`) evolve the framework. Platform-specific
+operational procedures are provided through dedicated skills (for example the
+`managing-github` skill in the
+[`forketyfork/agentic-skills`](https://github.com/forketyfork/agentic-skills)
+GitHub repository).
 
 ### The Workflow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,14 +2,14 @@
 
 ## System Overview
 
-Governance is a documentation-only repository that defines a federated governance
-framework for AI-assisted software projects. It contains no application code —
-only Markdown specifications, Bash scripts, Nix configuration, and GitHub Actions
-workflows. The repository produces two artifacts: agent command specifications
-(installed via symlinks into developer tool directories) and governance documents
-(consumed by humans and AI agents across multiple projects called "Lands"). Quality
-is enforced through Nix-managed pre-commit hooks and a CI pipeline that runs the
-same checks.
+Governance is a documentation-only repository that defines a federated
+governance framework for AI-assisted software projects. It contains no
+application code — only Markdown specifications, Bash scripts, Nix
+configuration, and GitHub Actions workflows. The repository produces three
+artifacts: command specifications, Codex skill metadata/support files used to
+build installed skills, and governance documents consumed by humans and AI
+agents across multiple projects called "Lands". Quality is enforced through
+Nix-managed pre-commit hooks and a CI pipeline that runs the same checks.
 
 ## Component Diagram
 
@@ -31,6 +31,10 @@ graph TD
         GOV["Governance commands\n_amend_"]
     end
 
+    subgraph codexskills["Codex Skill Support Files (.agents/skills/)"]
+        WRAP["Per-command metadata/assets\n_openai.yaml and optional support files_"]
+    end
+
     subgraph skills["External Skills (forketyfork/agentic-skills)"]
         GH["managing-github\n_GitHub CLI procedures_"]
     end
@@ -40,13 +44,15 @@ graph TD
     end
 
     subgraph tooling["Tooling"]
-        INSTALL["scripts/install-commands.sh\n_Symlinks commands to agent tools_"]
+        INSTALL["scripts/install-commands.sh\n_Symlinks commands and materializes Codex skills_"]
         NIX["flake.nix\n_Dev environment + pre-commit hooks_"]
         CI[".github/workflows/ci.yml\n_Lint & format pipeline_"]
     end
 
     INSTALL -->|reads| commands
+    INSTALL -->|reads| codexskills
     CI -->|runs| NIX
+    WRAP -->|paired with| commands
     PLAN -->|references| governance
     DOC -->|references| governance
     REV -->|references| governance
@@ -67,8 +73,9 @@ CONSTITUTION.md          (top-level authority)
 ├── ADMITTANCE.md        (references constitution)
 ├── FEDERATION.md        (references admittance checklist)
 ├── docs/PRD.md          (references constitution features)
-└── commands/*.md        (implement constitution workflows)
-    └── templates/*.md.template  (referenced by admittance)
+├── commands/*.md        (implement constitution workflows)
+├── .agents/skills/*     (Codex metadata and optional support files)
+└── templates/*.md.template  (referenced by admittance)
 ```
 
 **Rules:**
@@ -92,52 +99,66 @@ CONSTITUTION.md          (top-level authority)
    purpose section, a procedure section, an output format section, and a rules
    section. Do not invent a new structure. _(DR-001)_
 
-2. **Day-to-day commands must not reference governance documents:** use only the
+2. **Codex skill installs are materialized from command specs:** keep the
+   canonical workflow body in `commands/<name>.md` and store only Codex-specific
+   metadata or support files in `.agents/skills/<name>/`. The installer writes a
+   real `SKILL.md` into `~/.agents/skills/<name>/` because Codex does not load
+   symlinked `SKILL.md` files. _(DR-008)_
+
+3. **Day-to-day commands must not reference governance documents:** use only the
    target Land's `CLAUDE.md` and `docs/` files. Do not mention `CONSTITUTION.md`,
    `FEDERATION.md`, `ADMITTANCE.md`, or federation terminology. _(DR-002)_
 
-3. **All Markdown and shell changes must pass pre-commit hooks before merge:**
+4. **All Markdown and shell changes must pass pre-commit hooks before merge:**
    markdownlint-cli2, Prettier, ShellCheck, and shfmt. Do not disable or skip
    hooks. _(DR-003)_
 
-4. **Keep `AGENTS.md` as a symlink to `CLAUDE.md`:** never create a separate
+5. **Keep `AGENTS.md` as a symlink to `CLAUDE.md`:** never create a separate
    `AGENTS.md` file. _(DR-006)_
 
-5. **Use conventional commit messages:** all commits follow the Conventional
+6. **Use conventional commit messages:** all commits follow the Conventional
    Commits format. _(DR-007)_
 
 ## Where to Put New Code
 
-| I need to...                     | Put it in...                                                        |
-| -------------------------------- | ------------------------------------------------------------------- |
-| Add a new agent command          | `commands/<name>.md` — then run `install-commands.sh` to symlink it |
-| Add a platform-specific skill    | external skill catalog entry for `managing-<platform>`              |
-| Add a new project template       | `templates/<name>.md.template`                                      |
-| Change governance rules          | `CONSTITUTION.md` (requires explicit user approval)                 |
-| Change the admittance process    | `ADMITTANCE.md` (requires explicit user approval)                   |
-| Change the federation registry   | `FEDERATION.md` (requires explicit user approval)                   |
-| Add a new CI check               | `flake.nix` (add a hook) and verify in `.github/workflows/ci.yml`   |
-| Add a new linter config          | Root directory (e.g., `.markdownlint-cli2.jsonc`, `.prettierrc`)    |
-| Add a utility script             | `scripts/<name>.sh`                                                 |
-| Update product requirements      | `docs/PRD.md`                                                       |
-| Store temporary files during dev | `.tmp/` with unique filenames                                       |
+| I need to...                     | Put it in...                                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Add a new agent command          | `commands/<name>.md`, plus `.agents/skills/<name>/agents/openai.yaml`, then run `install-commands.sh`  |
+| Add Codex-only support files     | `.agents/skills/<name>/assets`, `.agents/skills/<name>/references`, or `.agents/skills/<name>/scripts` |
+| Adjust Codex skill metadata      | `.agents/skills/<name>/agents/openai.yaml`                                                             |
+| Add a platform-specific skill    | external skill catalog entry for `managing-<platform>`                                                 |
+| Add a new project template       | `templates/<name>.md.template`                                                                         |
+| Change governance rules          | `CONSTITUTION.md` (requires explicit user approval)                                                    |
+| Change the admittance process    | `ADMITTANCE.md` (requires explicit user approval)                                                      |
+| Change the federation registry   | `FEDERATION.md` (requires explicit user approval)                                                      |
+| Add a new CI check               | `flake.nix` (add a hook) and verify in `.github/workflows/ci.yml`                                      |
+| Add a new linter config          | Root directory (e.g., `.markdownlint-cli2.jsonc`, `.prettierrc`)                                       |
+| Add a utility script             | `scripts/<name>.sh`                                                                                    |
+| Update product requirements      | `docs/PRD.md`                                                                                          |
+| Store temporary files during dev | `.tmp/` with unique filenames                                                                          |
 
 ## Data Flow
 
 ### Command Installation Flow
 
 ```text
-commands/*.md
-     │
-     ▼
-scripts/install-commands.sh
-     │
-     ├──► ~/.claude/commands/*.md   (symlinks)
-     └──► ~/.codex/prompts/*.md     (symlinks)
+commands/*.md                    .agents/skills/*
+     │                                 │
+     └──────────────┬──────────────────┘
+                    ▼
+        scripts/install-commands.sh
+                    │
+                    ├──► ~/.claude/commands/*.md        (symlinks)
+                    └──► ~/.agents/skills/*/SKILL.md    (materialized files)
+                               plus support files
 ```
 
-The script is idempotent: existing correct symlinks are skipped, stale symlinks
-are updated, and non-symlink files at the target path are never overwritten.
+The install script is idempotent: existing correct Claude symlinks are skipped,
+Codex skill files are hard-linked when possible and copied otherwise, stale
+legacy Codex skill-directory symlinks previously created by this repository are
+replaced with real directories, non-file and non-directory conflicts are not
+overwritten, and only legacy prompt symlinks previously managed by this
+repository are removed.
 
 ### Quality Check Flow
 
@@ -185,13 +206,13 @@ from Review to Merge (PR review). The Reflect phase is additive and ungated.
 
 ### Entry Points
 
-| Entry point              | How data gets in                                             |
-| ------------------------ | ------------------------------------------------------------ |
-| `install-commands.sh`    | Developer runs the script manually                           |
-| `nix develop` / `direnv` | Developer activates the dev environment                      |
-| Pre-commit hooks         | Triggered automatically on `git commit`                      |
-| CI pipeline              | Triggered on push to `main` or PR targeting `main`           |
-| Agent command invocation | Developer invokes `/command` in Claude Code, Codex, or Junie |
+| Entry point               | How data gets in                                                                                      |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `install-commands.sh`     | Developer runs the script manually                                                                    |
+| `nix develop` / `direnv`  | Developer activates the dev environment                                                               |
+| Pre-commit hooks          | Triggered automatically on `git commit`                                                               |
+| CI pipeline               | Triggered on push to `main` or PR targeting `main`                                                    |
+| Agent workflow invocation | Developer invokes `/command` in Claude Code, `$skill` in Codex, or an equivalent entry point in Junie |
 
 ### Storage
 
@@ -199,6 +220,7 @@ from Review to Merge (PR review). The Reflect phase is additive and ungated.
 | -------------------------- | -------------------------------------------------------------------------- |
 | Governance documents       | Repository root (`*.md`)                                                   |
 | Command specifications     | `commands/*.md`                                                            |
+| Codex skill support files  | `.agents/skills/*`                                                         |
 | Templates                  | `templates/*.md.template`                                                  |
 | Linter/formatter config    | Root dotfiles (`.markdownlint-cli2.jsonc`, `.prettierrc`, `.editorconfig`) |
 | Nix environment definition | `flake.nix`, `flake.lock`                                                  |
@@ -207,42 +229,44 @@ from Review to Merge (PR review). The Reflect phase is additive and ungated.
 
 ### Exit Points
 
-| Exit point     | How data gets out                                                        |
-| -------------- | ------------------------------------------------------------------------ |
-| Symlinks       | Command specs available in `~/.claude/commands/` and `~/.codex/prompts/` |
-| CI status      | Pass/fail reported to GitHub PR checks                                   |
-| Agent behavior | Commands shape agent output in target Land repositories                  |
-| Templates      | Copied to new Lands during admittance                                    |
+| Exit point      | How data gets out                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Install outputs | Command specs available in `~/.claude/commands/` and materialized Codex skills in `~/.agents/skills/` |
+| CI status       | Pass/fail reported to GitHub PR checks                                                                |
+| Agent behavior  | Commands and installed Codex skills shape agent output in target Land repositories                    |
+| Templates       | Copied to new Lands during admittance                                                                 |
 
 ## Module Boundary Table
 
-| Module                   | Responsibility                                               | Public API                                                 | Dependencies                  |
-| ------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------- | ----------------------------- |
-| Governance documents     | Define principles, processes, and federation registry        | `CONSTITUTION.md`, `ADMITTANCE.md`, `FEDERATION.md`        | None                          |
-| Product requirements     | Document this repository's own features and success criteria | `docs/PRD.md`                                              | Governance documents          |
-| Planning commands        | Interview developer, produce issues                          | `commands/bug.md`, `feature.md`, `tech.md`                 | Target Land's CLAUDE.md, docs |
-| Documentation commands   | Generate/update standard project documents                   | `commands/prd.md`, `architecture.md`, `traceability.md`    | Target Land's codebase, docs  |
-| Delivery commands        | Implement issues, ship PRs                                   | `commands/implement.md`, `ship.md`                         | Target Land's CLAUDE.md, docs |
-| Review commands          | Guide PR review, address comments                            | `commands/review.md`, `address.md`                         | Target Land's CLAUDE.md, docs |
-| Session commands         | Capture learnings from work sessions                         | `commands/learn.md`, `knowledge.md`                        | Target Land's CLAUDE.md       |
-| Governance commands      | Propose amendments to governance repo                        | `commands/amend.md`                                        | Governance documents          |
-| External platform skills | Vendor-specific CLI procedures                               | `managing-github` skill (external catalog)                 | None (reference only)         |
-| Templates                | Starter documents for new Lands                              | `templates/CLAUDE.md.template`, `CONVENTIONS.md.template`  | Governance documents (link)   |
-| Install script           | Symlink commands into agent tool directories                 | `scripts/install-commands.sh`                              | `commands/`                   |
-| Nix environment          | Dev shell with tools and pre-commit hooks                    | `flake.nix`, `flake.lock`                                  | nixpkgs, git-hooks.nix        |
-| CI pipeline              | Automated lint and format checks on PR/push                  | `.github/workflows/ci.yml`                                 | Nix environment               |
-| Editor/linter config     | Tool configuration for consistent formatting                 | `.editorconfig`, `.prettierrc`, `.markdownlint-cli2.jsonc` | None                          |
+| Module                    | Responsibility                                               | Public API                                                 | Dependencies                   |
+| ------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------ |
+| Governance documents      | Define principles, processes, and federation registry        | `CONSTITUTION.md`, `ADMITTANCE.md`, `FEDERATION.md`        | None                           |
+| Product requirements      | Document this repository's own features and success criteria | `docs/PRD.md`                                              | Governance documents           |
+| Planning commands         | Interview developer, produce issues                          | `commands/bug.md`, `feature.md`, `tech.md`                 | Target Land's CLAUDE.md, docs  |
+| Documentation commands    | Generate/update standard project documents                   | `commands/prd.md`, `architecture.md`, `traceability.md`    | Target Land's codebase, docs   |
+| Delivery commands         | Implement issues, ship PRs                                   | `commands/implement.md`, `ship.md`                         | Target Land's CLAUDE.md, docs  |
+| Review commands           | Guide PR review, address comments                            | `commands/review.md`, `address.md`                         | Target Land's CLAUDE.md, docs  |
+| Session commands          | Capture learnings from work sessions                         | `commands/learn.md`, `knowledge.md`                        | Target Land's CLAUDE.md        |
+| Governance commands       | Propose amendments to governance repo                        | `commands/amend.md`                                        | Governance documents           |
+| Codex skill support files | Provide Codex-only metadata and optional bundled resources   | `.agents/skills/*`                                         | `commands/`                    |
+| External platform skills  | Vendor-specific CLI procedures                               | `managing-github` skill (external catalog)                 | None (reference only)          |
+| Templates                 | Starter documents for new Lands                              | `templates/CLAUDE.md.template`, `CONVENTIONS.md.template`  | Governance documents (link)    |
+| Install script            | Symlink Claude commands and materialize Codex skills         | `scripts/install-commands.sh`                              | `commands/`, `.agents/skills/` |
+| Nix environment           | Dev shell with tools and pre-commit hooks                    | `flake.nix`, `flake.lock`                                  | nixpkgs, git-hooks.nix         |
+| CI pipeline               | Automated lint and format checks on PR/push                  | `.github/workflows/ci.yml`                                 | Nix environment                |
+| Editor/linter config      | Tool configuration for consistent formatting                 | `.editorconfig`, `.prettierrc`, `.markdownlint-cli2.jsonc` | None                           |
 
 ## Key Architectural Decisions
 
 Decision details are stored in `docs/decisions/` and summarized here.
 
-| ID       | Title                                             | Status   | Date       | Link                                                                                                                                                |
-| -------- | ------------------------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DR-001` | Markdown-based command specifications             | Accepted | 2026-02-16 | [docs/decisions/DR-001-markdown-based-command-specifications.md](decisions/DR-001-markdown-based-command-specifications.md)                         |
-| `DR-002` | Day-to-day commands are governance-unaware        | Accepted | 2026-02-16 | [docs/decisions/DR-002-day-to-day-commands-are-governance-unaware.md](decisions/DR-002-day-to-day-commands-are-governance-unaware.md)               |
-| `DR-003` | Nix-based reproducible toolchain                  | Accepted | 2026-02-16 | [docs/decisions/DR-003-nix-based-reproducible-toolchain.md](decisions/DR-003-nix-based-reproducible-toolchain.md)                                   |
-| `DR-004` | Symlink-based command distribution                | Accepted | 2026-02-16 | [docs/decisions/DR-004-symlink-based-command-distribution.md](decisions/DR-004-symlink-based-command-distribution.md)                               |
-| `DR-005` | Infrastructure-agnostic command specifications    | Accepted | 2026-02-16 | [docs/decisions/DR-005-infrastructure-agnostic-command-specifications.md](decisions/DR-005-infrastructure-agnostic-command-specifications.md)       |
-| `DR-006` | Single-file agent instructions with symlink alias | Accepted | 2026-02-16 | [docs/decisions/DR-006-single-file-agent-instructions-with-symlink-alias.md](decisions/DR-006-single-file-agent-instructions-with-symlink-alias.md) |
-| `DR-007` | Conventional commit messages                      | Accepted | 2026-03-05 | [docs/decisions/DR-007-conventional-commit-messages.md](decisions/DR-007-conventional-commit-messages.md)                                           |
+| ID       | Title                                             | Status     | Date       | Link                                                                                                                                                |
+| -------- | ------------------------------------------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DR-001` | Markdown-based command specifications             | Accepted   | 2026-02-16 | [docs/decisions/DR-001-markdown-based-command-specifications.md](decisions/DR-001-markdown-based-command-specifications.md)                         |
+| `DR-002` | Day-to-day commands are governance-unaware        | Accepted   | 2026-02-16 | [docs/decisions/DR-002-day-to-day-commands-are-governance-unaware.md](decisions/DR-002-day-to-day-commands-are-governance-unaware.md)               |
+| `DR-003` | Nix-based reproducible toolchain                  | Accepted   | 2026-02-16 | [docs/decisions/DR-003-nix-based-reproducible-toolchain.md](decisions/DR-003-nix-based-reproducible-toolchain.md)                                   |
+| `DR-004` | Symlink-based command distribution                | Superseded | 2026-02-16 | [docs/decisions/DR-004-symlink-based-command-distribution.md](decisions/DR-004-symlink-based-command-distribution.md)                               |
+| `DR-005` | Infrastructure-agnostic command specifications    | Accepted   | 2026-02-16 | [docs/decisions/DR-005-infrastructure-agnostic-command-specifications.md](decisions/DR-005-infrastructure-agnostic-command-specifications.md)       |
+| `DR-006` | Single-file agent instructions with symlink alias | Accepted   | 2026-02-16 | [docs/decisions/DR-006-single-file-agent-instructions-with-symlink-alias.md](decisions/DR-006-single-file-agent-instructions-with-symlink-alias.md) |
+| `DR-007` | Conventional commit messages                      | Accepted   | 2026-03-05 | [docs/decisions/DR-007-conventional-commit-messages.md](decisions/DR-007-conventional-commit-messages.md)                                           |
+| `DR-008` | Codex skills materialized from command specs      | Accepted   | 2026-04-02 | [docs/decisions/DR-008-codex-skill-wrappers-backed-by-command-specs.md](decisions/DR-008-codex-skill-wrappers-backed-by-command-specs.md)           |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -25,10 +25,10 @@ guardrails, structured workflows, and human checkpoints that prevent that rot.
    Workflow commands follow the Land's issue/PR linkage convention declared in
    `CLAUDE.md`.
 
-3. **F3: Command Installation** — A script that symlinks all command
-   specifications into the developer's agent tool configuration directories
-   (Claude Code and Codex), so that changes to command specs take effect
-   immediately across all tools.
+3. **F3: Agent Workflow Installation** — A script that symlinks Claude command
+   specifications and materializes Codex skills from command specs plus
+   Codex-specific metadata into the developer's agent tool configuration
+   directories.
 
 4. **F4: Land Admittance** — A phased process for bringing a new or existing
    project under governance: foundation setup (including `CLAUDE.md` with
@@ -110,8 +110,8 @@ governed projects operate.
 ### F2: Agent Command Specifications
 
 1. Developer invokes a command (e.g., `/feature`) in their AI coding agent.
-2. The agent reads the corresponding command specification from the symlinked
-   file.
+2. The agent reads the corresponding workflow specification from the installed
+   command file or skill `SKILL.md`.
 3. The agent follows the specification's procedure: interviewing the developer,
    reading project docs, and producing the expected output (an issue, a PR,
    a review walkthrough, etc.).
@@ -119,17 +119,20 @@ governed projects operate.
 **Result:** The agent performs a structured task with consistent quality across
 all projects.
 
-### F3: Command Installation
+### F3: Agent Workflow Installation
 
 1. Developer runs `./scripts/install-commands.sh`.
-2. The script creates symlinks from `commands/*.md` to `~/.claude/commands/` and
-   `~/.codex/prompts/`.
-3. If a symlink already points to the correct target, it is skipped. If it
-   points elsewhere, it is updated. Non-symlink files at the target path are not
-   overwritten.
+2. The script creates symlinks from `commands/*.md` to `~/.claude/commands/`
+   and materializes real skill directories in `~/.agents/skills/` by writing
+   `SKILL.md` from `commands/*.md` plus any Codex-specific support files from
+   `.agents/skills/*`.
+3. If the source and target live on the same filesystem, the script hard-links
+   files so skill-body changes propagate without another copy step. Otherwise it
+   copies them. Legacy prompt symlinks in `~/.codex/prompts/` that were
+   previously managed by this repository are removed.
 
-**Result:** All agent commands are available in the developer's Claude Code and
-Codex environments, and future edits to command specs propagate instantly.
+**Result:** Claude command specs and Codex skills are available in the
+developer's environments.
 
 ### F4: Land Admittance
 
@@ -281,9 +284,12 @@ agents adapt.
   defining the command's purpose, input, procedure, output format, and
   behavioral rules.
 - **F3:** Running `install-commands.sh` creates working symlinks to
-  `~/.claude/commands/` and `~/.codex/prompts/` for every command spec; the
-  script is idempotent and handles existing symlinks, updated targets, and
-  non-symlink conflicts.
+  `~/.claude/commands/` for command specs and materialized skill directories in
+  `~/.agents/skills/` for Codex. The script is idempotent, replaces its own
+  legacy skill-directory symlinks with real directories, hard-links files when
+  possible, falls back to copying when necessary, avoids non-file and
+  non-directory conflicts, and removes only the legacy `~/.codex/prompts/`
+  symlinks previously managed by this repository.
 - **F4:** `ADMITTANCE.md` describes all phases with concrete steps and
   includes a checklist for when a Land reaches "Governed" status.
 - **F5:** `FEDERATION.md` contains a registry table with columns for standard

--- a/docs/decisions/DR-004-symlink-based-command-distribution.md
+++ b/docs/decisions/DR-004-symlink-based-command-distribution.md
@@ -1,11 +1,14 @@
 # DR-004: Symlink-based command distribution
 
-**Status:** Accepted
+**Status:** Superseded by DR-008
 **Date:** 2026-02-16
 
 ## Decision
 
 `install-commands.sh` creates symlinks from `commands/*.md` to agent tool directories (`~/.claude/commands/`, `~/.codex/prompts/`) rather than copying files.
+
+This decision remains in force for Claude Code. Codex prompt installation was
+superseded when Codex moved from prompt files to skill folders.
 
 ## Context
 

--- a/docs/decisions/DR-008-codex-skill-wrappers-backed-by-command-specs.md
+++ b/docs/decisions/DR-008-codex-skill-wrappers-backed-by-command-specs.md
@@ -1,0 +1,61 @@
+# DR-008: Codex skills materialized from command specs
+
+**Status:** Accepted
+**Date:** 2026-04-02
+
+## Decision
+
+Codex workflows are installed as real skill directories under
+`~/.agents/skills/`. `install-commands.sh` writes each installed `SKILL.md`
+from the canonical `commands/<name>.md` file and then adds any Codex-specific
+metadata or support files from `.agents/skills/<name>/`.
+
+Claude Code continues to consume `commands/*.md` via symlinks in
+`~/.claude/commands/`.
+
+## Context
+
+Codex prompt files under `~/.codex/prompts/` are no longer the preferred
+workflow distribution mechanism. Codex skills require directory-based structure
+with `SKILL.md`, while this repository already uses `commands/*.md` as the
+canonical workflow specification format and still needs to support Claude
+Code's command installation model.
+
+The original migration approach used symlinked skill directories and symlinked
+`SKILL.md` files. Codex follows symlinked skill directories, but it does not
+discover symlinked `SKILL.md` files. That makes a repo-local `SKILL.md`
+symlink an unreliable installation strategy even though it keeps one apparent
+source of truth.
+
+Materializing `SKILL.md` at install time preserves `commands/*.md` as the
+source of truth while producing a layout Codex reliably loads.
+
+## Consequences
+
+- `commands/*.md` remains the single source of truth for workflow instructions.
+- Codex-specific metadata can evolve independently in
+  `.agents/skills/<name>/agents/openai.yaml`.
+- `install-commands.sh` must manage two output formats: Claude command files and
+  materialized Codex skill directories.
+- On the same filesystem, the installer can hard-link files so command-body
+  edits propagate to the installed Codex skills without another copy step.
+- On different filesystems, the installer falls back to copying files, so the
+  installer must be rerun after changes.
+- Legacy symlinks in `~/.codex/prompts/` can be cleaned up safely when they are
+  known to have been created by this repository.
+
+## Alternatives considered
+
+### 1. Duplicate every workflow into separate Claude and Codex files
+
+Rejected because it creates drift risk and doubles maintenance cost.
+
+### 2. Keep symlinked `SKILL.md` files inside checked-in skill folders
+
+Rejected because Codex does not discover symlinked `SKILL.md` files.
+
+### 3. Package the workflows as a Codex plugin immediately
+
+Rejected for now because the existing symlink-based installation model already
+fits the repository's workflow, and moving to plugins would add packaging and
+distribution complexity beyond the current migration.

--- a/scripts/install-commands.sh
+++ b/scripts/install-commands.sh
@@ -63,11 +63,38 @@ normalize_path() {
 	local path="$1"
 	local dir_path
 	local base_name
+	local dir_abs
 
 	dir_path="$(dirname "${path}")"
 	base_name="$(basename "${path}")"
 
-	printf "%s/%s\n" "$(cd "${dir_path}" && pwd -P)" "${base_name}"
+	if dir_abs="$(cd "${dir_path}" 2>/dev/null && pwd -P)"; then
+		printf "%s/%s\n" "${dir_abs}" "${base_name}"
+		return
+	fi
+
+	case "${path}" in
+	/*)
+		printf "%s\n" "${path}"
+		;;
+	*)
+		printf "%s/%s\n" "${PWD}" "${path}"
+		;;
+	esac
+}
+
+looks_like_legacy_skill_target() {
+	local path="$1"
+	local skill_name="$2"
+
+	case "${path}" in
+	*/.agents/skills/"${skill_name}" | */.agents/skills/"${skill_name}"/ | .agents/skills/"${skill_name}" | .agents/skills/"${skill_name}"/)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
 }
 
 normalized_link_target() {
@@ -92,7 +119,7 @@ materialize_file() {
 
 	if [ -e "${target_path}" ] && [ ! -f "${target_path}" ] && [ ! -L "${target_path}" ]; then
 		echo "Skipping: ${target_path} exists and is not a file" >&2
-		return 1
+		return 0
 	fi
 
 	if [ -L "${target_path}" ]; then
@@ -191,9 +218,10 @@ for cmd_file in "${COMMANDS_DIR}"/*.md; do
 	target_skill_dir="${CODEX_SKILLS_DIR}/${skill_name}"
 
 	if [ -L "${target_skill_dir}" ]; then
+		raw_existing_target="$(readlink "${target_skill_dir}")"
 		existing_target="$(normalized_link_target "${target_skill_dir}")"
 		expected_legacy_target="$(normalize_path "${skill_dir}")"
-		if [ "${existing_target}" = "${expected_legacy_target}" ]; then
+		if [ "${existing_target}" = "${expected_legacy_target}" ] || looks_like_legacy_skill_target "${raw_existing_target}" "${skill_name}"; then
 			echo "Replacing legacy Codex skill symlink: ${target_skill_dir}"
 			rm "${target_skill_dir}"
 		else

--- a/scripts/install-commands.sh
+++ b/scripts/install-commands.sh
@@ -3,40 +3,209 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMANDS_DIR="${SCRIPT_DIR}/../commands"
+SKILLS_DIR="${SCRIPT_DIR}/../.agents/skills"
+SKILLS_FILENAME="SKILL.md"
 
-TARGET_DIRS=(
-	"${HOME}/.claude/commands"
-	"${HOME}/.codex/prompts"
-)
+CLAUDE_COMMANDS_DIR="${HOME}/.claude/commands"
+CODEX_SKILLS_DIR="${HOME}/.agents/skills"
+LEGACY_CODEX_PROMPTS_DIR="${HOME}/.codex/prompts"
 
 if [ ! -d "${COMMANDS_DIR}" ]; then
 	echo "Error: commands directory not found at ${COMMANDS_DIR}" >&2
 	exit 1
 fi
 
-for target_dir in "${TARGET_DIRS[@]}"; do
-	mkdir -p "${target_dir}"
+if [ ! -d "${SKILLS_DIR}" ]; then
+	echo "Error: skills directory not found at ${SKILLS_DIR}" >&2
+	exit 1
+fi
 
-	for cmd_file in "${COMMANDS_DIR}"/*.md; do
-		[ -f "${cmd_file}" ] || continue
+ensure_symlink() {
+	local source_path="$1"
+	local link_path="$2"
+	local normalized_source
 
-		filename="$(basename "${cmd_file}")"
-		link_path="${target_dir}/${filename}"
+	normalized_source="$(normalize_path "${source_path}")"
 
-		if [ -L "${link_path}" ]; then
-			existing_target="$(readlink "${link_path}")"
-			if [ "${existing_target}" = "${cmd_file}" ]; then
-				echo "Already linked: ${link_path}"
-				continue
-			fi
-			echo "Updating symlink: ${link_path} (was → ${existing_target})"
-			rm "${link_path}"
-		elif [ -e "${link_path}" ]; then
-			echo "Skipping: ${link_path} exists and is not a symlink" >&2
+	if [ -L "${link_path}" ]; then
+		local existing_target
+		existing_target="$(normalized_link_target "${link_path}")"
+		if [ "${existing_target}" = "${normalized_source}" ]; then
+			echo "Already linked: ${link_path}"
+			return
+		fi
+		echo "Updating symlink: ${link_path} (was → ${existing_target})"
+		rm "${link_path}"
+	elif [ -e "${link_path}" ]; then
+		echo "Skipping: ${link_path} exists and is not a symlink" >&2
+		return
+	fi
+
+	ln -s "${source_path}" "${link_path}"
+	echo "Linked: ${link_path} → ${source_path}"
+}
+
+ensure_directory() {
+	local dir_path="$1"
+
+	if [ -L "${dir_path}" ]; then
+		echo "Replacing symlinked directory: ${dir_path}"
+		rm "${dir_path}"
+	elif [ -e "${dir_path}" ] && [ ! -d "${dir_path}" ]; then
+		echo "Skipping: ${dir_path} exists and is not a directory" >&2
+		return 1
+	fi
+
+	mkdir -p "${dir_path}"
+}
+
+normalize_path() {
+	local path="$1"
+	local dir_path
+	local base_name
+
+	dir_path="$(dirname "${path}")"
+	base_name="$(basename "${path}")"
+
+	printf "%s/%s\n" "$(cd "${dir_path}" && pwd -P)" "${base_name}"
+}
+
+normalized_link_target() {
+	local link_path="$1"
+	local raw_target
+
+	raw_target="$(readlink "${link_path}")"
+
+	case "${raw_target}" in
+	/*)
+		normalize_path "${raw_target}"
+		;;
+	*)
+		normalize_path "$(dirname "${link_path}")/${raw_target}"
+		;;
+	esac
+}
+
+materialize_file() {
+	local source_path="$1"
+	local target_path="$2"
+
+	if [ -e "${target_path}" ] && [ ! -f "${target_path}" ] && [ ! -L "${target_path}" ]; then
+		echo "Skipping: ${target_path} exists and is not a file" >&2
+		return 1
+	fi
+
+	if [ -L "${target_path}" ]; then
+		rm "${target_path}"
+	fi
+
+	if [ -f "${target_path}" ] && cmp -s "${source_path}" "${target_path}"; then
+		echo "Already materialized: ${target_path}"
+		return 0
+	fi
+
+	rm -f "${target_path}"
+
+	if ln "${source_path}" "${target_path}" 2>/dev/null; then
+		echo "Hard linked: ${target_path} → ${source_path}"
+		return 0
+	fi
+
+	cp "${source_path}" "${target_path}"
+	echo "Copied: ${target_path} ← ${source_path}"
+}
+
+sync_skill_support_tree() {
+	local source_root="$1"
+	local target_root="$2"
+
+	if [ ! -d "${source_root}" ]; then
+		return 0
+	fi
+
+	while IFS= read -r -d '' source_path; do
+		local relative_path
+		local target_path
+		local base_name
+
+		relative_path="${source_path#"${source_root}/"}"
+		target_path="${target_root}/${relative_path}"
+		base_name="$(basename "${source_path}")"
+
+		if [ "${base_name}" = "${SKILLS_FILENAME}" ]; then
 			continue
 		fi
 
-		ln -s "${cmd_file}" "${link_path}"
-		echo "Linked: ${link_path} → ${cmd_file}"
-	done
+		if [ -d "${source_path}" ]; then
+			ensure_directory "${target_path}" || continue
+			continue
+		fi
+
+		if [ ! -f "${source_path}" ]; then
+			echo "Skipping unsupported support entry: ${source_path}" >&2
+			continue
+		fi
+
+		ensure_directory "$(dirname "${target_path}")" || continue
+		materialize_file "${source_path}" "${target_path}"
+	done < <(find "${source_root}" -mindepth 1 -print0)
+}
+
+remove_legacy_prompt_symlink() {
+	local legacy_path="$1"
+	local command_target="$2"
+	local normalized_existing_target
+	local normalized_command_target
+
+	if [ ! -L "${legacy_path}" ]; then
+		return
+	fi
+
+	normalized_existing_target="$(normalized_link_target "${legacy_path}")"
+	normalized_command_target="$(normalize_path "${command_target}")"
+
+	if [ "${normalized_existing_target}" != "${normalized_command_target}" ]; then
+		echo "Leaving legacy prompt symlink in place: ${legacy_path} → ${normalized_existing_target}"
+		return
+	fi
+
+	rm "${legacy_path}"
+	echo "Removed legacy prompt symlink: ${legacy_path}"
+}
+
+mkdir -p "${CLAUDE_COMMANDS_DIR}"
+mkdir -p "${CODEX_SKILLS_DIR}"
+
+for cmd_file in "${COMMANDS_DIR}"/*.md; do
+	[ -f "${cmd_file}" ] || continue
+
+	filename="$(basename "${cmd_file}")"
+	ensure_symlink "${cmd_file}" "${CLAUDE_COMMANDS_DIR}/${filename}"
+done
+
+for cmd_file in "${COMMANDS_DIR}"/*.md; do
+	[ -f "${cmd_file}" ] || continue
+
+	skill_name="$(basename "${cmd_file}" .md)"
+	skill_dir="${SKILLS_DIR}/${skill_name}"
+	target_skill_dir="${CODEX_SKILLS_DIR}/${skill_name}"
+
+	if [ -L "${target_skill_dir}" ]; then
+		existing_target="$(normalized_link_target "${target_skill_dir}")"
+		expected_legacy_target="$(normalize_path "${skill_dir}")"
+		if [ "${existing_target}" = "${expected_legacy_target}" ]; then
+			echo "Replacing legacy Codex skill symlink: ${target_skill_dir}"
+			rm "${target_skill_dir}"
+		else
+			echo "Skipping: ${target_skill_dir} is a symlink managed elsewhere (${existing_target})" >&2
+			continue
+		fi
+	fi
+
+	ensure_directory "${target_skill_dir}" || continue
+	materialize_file "${cmd_file}" "${target_skill_dir}/${SKILLS_FILENAME}"
+	sync_skill_support_tree "${skill_dir}" "${target_skill_dir}"
+	remove_legacy_prompt_symlink \
+		"${LEGACY_CODEX_PROMPTS_DIR}/${skill_name}.md" \
+		"${cmd_file}"
 done


### PR DESCRIPTION
## Solution

Codex stopped loading the installed workflows after the migration away from
prompts because the first pass kept `SKILL.md` as a symlink. That turns out to
be the one part Codex does not discover reliably.

This change keeps `commands/*.md` as the source of truth, keeps Claude on
symlinked command files, and has `install-commands.sh` materialize real skill
directories for Codex under `~/.agents/skills`. The installer now writes a real
`SKILL.md`, brings over Codex-only metadata from `.agents/skills/*`, hard-links
files when it can, copies when it has to, replaces the old managed skill-dir
symlinks, and removes the legacy prompt symlinks this repo used to create.

The docs and decision records now describe that model directly, and `DR-008`
records why we need real installed `SKILL.md` files for Codex.

## Automated checks

- `pre-commit run --all-files`
- `nix flake check`

## Test plan

- [ ] Run `./scripts/install-commands.sh` in a temp `HOME` that still has the
      old managed `~/.agents/skills/<name>` symlink layout and confirm the
      install replaces it with a real directory containing a real `SKILL.md`.
- [ ] Start a fresh Codex session after install and confirm the skills appear
      and can be invoked.
