### PR TITLE
docs(review): document pending-review posting mechanics

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -140,3 +140,11 @@ Scan for:
 - When you flag a problem, suggest what the fix looks like. Don't just say "this is wrong."
 - Do not rubber-stamp. If the PR is genuinely clean, say so briefly and specifically — explain what makes it clean.
 - If you're uncertain, say so: "I'm not sure about this — worth checking."
+
+## Posting the Review
+
+`/review` posts nothing to the hosting platform unless the user explicitly asks. The default is a **pending** draft, visible only to its author until they submit manually — never submit/approve/request-changes on their behalf without explicit authorization. For non-GitHub platforms, use the equivalent draft mechanism.
+
+### GitHub
+
+POST one payload to `repos/{owner}/{repo}/pulls/{n}/reviews` with `commit_id` (the **full** SHA via `gh api … --jq .head.sha`; abbreviated is rejected), top-level `body`, and `comments[]`. **Omit `event`** — that keeps the review PENDING (`COMMENT`/`APPROVE`/`REQUEST_CHANGES` publish it). Each inline comment must anchor to a new-side line inside a diff hunk; context lines between hunks fail with "Line could not be resolved". Parse `@@ -X,Y +A,B @@` headers — valid new-side lines are `A` through `A+B-1`. Verify the response shows `"state": "PENDING"`, then hand the review ID to the user (they submit, or discard via `gh api -X DELETE .../reviews/<id>`, themselves).

--- a/commands/review.md
+++ b/commands/review.md
@@ -143,8 +143,4 @@ Scan for:
 
 ## Posting the Review
 
-`/review` posts nothing to the hosting platform unless the user explicitly asks. The default is a **pending** draft, visible only to its author until they submit manually — never submit/approve/request-changes on their behalf without explicit authorization. For non-GitHub platforms, use the equivalent draft mechanism.
-
-### GitHub
-
-POST one payload to `repos/{owner}/{repo}/pulls/{n}/reviews` with `commit_id` (the **full** SHA via `gh api … --jq .head.sha`; abbreviated is rejected), top-level `body`, and `comments[]`. **Omit `event`** — that keeps the review PENDING (`COMMENT`/`APPROVE`/`REQUEST_CHANGES` publish it). Each inline comment must anchor to a new-side line inside a diff hunk; context lines between hunks fail with "Line could not be resolved". Parse `@@ -X,Y +A,B @@` headers — valid new-side lines are `A` through `A+B-1`. Verify the response shows `"state": "PENDING"`, then hand the review ID to the user (they submit, or discard via `gh api -X DELETE .../reviews/<id>`, themselves).
+`/review` posts nothing to the source code hosting platform unless the user explicitly asks. Even then, the default is a **pending** draft, visible only to its author until they submit manually — never submit, approve, or request-changes on the user's behalf without explicit authorization. For the platform-specific mechanics, consult the hosting-platform skill named in the project's `CLAUDE.md` (for example, `managing-github`).


### PR DESCRIPTION
## Origin

A `/review` session on `JetBrains/jcp-air#1276` produced an eight-step verdict and the user asked for a draft GitHub review with inline comments. Three failures before it worked:

1. Initial payload missing `commit_id`.
2. Abbreviated `commit_id` rejected as `"invalid GitObjectID"`.
3. Inline-comment line numbers outside diff hunks rejected as `"Line could not be resolved"`.

The mechanics that ultimately worked:

- omit the `event` field to keep the review PENDING
- use the **full** PR head SHA (`gh api … --jq .head.sha`)
- anchor inline comments only to lines inside diff hunks (parse `@@ -X,Y +A,B @@`)
- POST one payload with `body` + `comments[]` to `/pulls/{n}/reviews`

`commands/review.md` was silent on how to act on the verdict beyond producing it. The mechanics belong there so the next agent does not relearn them.

## Classification

Command change → `commands/review.md`. Pure addition of a `## Posting the Review` section. No Constitution / Admittance / Federation impact.

## Change

Adds eight lines at the end of `commands/review.md`:

- A preamble: nothing is posted without explicit user request; the default for any agent-posted review is **pending**; never submit/approve/request-changes on the user's behalf without authorization. For non-GitHub platforms, use the equivalent draft mechanism.
- A `### GitHub` subsection with the recipe condensed into a single dense paragraph (full SHA, omit `event`, hunk-bounded comment lines, verify `state: PENDING`, hand off the review ID).

Total file length: 150 lines (at the documented ceiling).

## Affected Lands

Any project that uses `/review`. Once this merges and `scripts/install-commands.sh` runs, every Land's installed `review.md` symlink picks up the new section automatically. No per-Land migration; no CLAUDE.md updates required.

## Verification

- `wc -l commands/review.md` → 150 (at the documented ceiling, not over).
- `pre-commit run --files commands/review.md` → all hooks pass (check-conventions, ls-lint, markdownlint-cli2, prettier).

## Out of scope

Possible follow-up worth a separate amendment: the same trap of "agent silently collapses a stepwise command into one shot when the brief asks for a written artifact" likely affects other interview-style commands too. Not addressed here per the *one insight per amendment* rule.