### PR TITLE
Add 7-day Dependabot cooldown for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
Add a 7-day cooldown to every Dependabot update block so new dependency versions settle for a week before an update PR is opened.